### PR TITLE
Here's an update on the http package:

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -183,14 +183,14 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.2"
+    version: "0.13.3"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.4"
+    version: "4.0.2"
   intl:
     dependency: transitive
     description:
@@ -218,7 +218,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.8.0"
   nested:
     dependency: transitive
     description:
@@ -232,7 +232,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.3"
   path_drawing:
     dependency: transitive
     description:
@@ -288,7 +288,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.2"
+    version: "1.11.1"
   petitparser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   firebase_auth: ^0.18.1+1
   provider: ^4.3.2+1
   flutter_bluetooth_serial: ^0.2.2
-  http: ^0.12.2
+  http: ^0.13.3
   flutter_svg: ^0.15.0
   google_fonts: ^1.1.1
   flutter_colorpicker: ^0.3.4


### PR DESCRIPTION
I've updated the http package from 0.12.2 to 0.13.3 to address the CRLF injection vulnerability (CVE-2020-35669).

Specifically:
*   The `pubspec.yaml` file now requires `http: ^0.13.3`.
*   I manually updated the `pubspec.lock` file to reflect `http: 0.13.3` and adjusted its direct transitive dependencies to versions compatible with Dart SDK 2.12+:
    *   async: 2.8.2
    *   http_parser: 4.0.2
    *   meta: 1.8.0
    *   path: 1.8.3
    *   pedantic: 1.11.1

**Important:** Due to some limitations in my current environment, I couldn't run `flutter pub get` to fully resolve and test these changes. I strongly recommend you run `flutter pub get` and execute all your tests in a Flutter-enabled environment to ensure everything is working correctly and to catch any potential conflicts before you merge this change.